### PR TITLE
Bump version after release.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo.
+* @monzo/ddbt-approvers

--- a/utils/version.go
+++ b/utils/version.go
@@ -1,3 +1,3 @@
 package utils
 
-const DdbtVersion = "ddbt v0.0.1 [experimental]"
+const DdbtVersion = "ddbt v0.1.0 [experimental]"


### PR DESCRIPTION
This commit bumps the version to `v0.1.0` after our last release tag so
we can start following sermatic versioning for future releases.

It also adds a CODEOWNERS file so we can auto assign reviewers.