### PR TITLE
A couple of quality of life updates

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -6,7 +6,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var file string
+
 func init() {
+	completionCmd.Flags().StringVar(&file, "file", "", "file to which output has to be written")
+	_ = completionCmd.MarkFlagFilename("file")
+
 	rootCmd.AddCommand(completionCmd)
 }
 
@@ -38,14 +43,34 @@ $ ddbt completion zsh > "${fpath[1]}/_ddbt"
 
 # You will need to start a new shell for this setup to take effect.`,
 	DisableFlagsInUseLine: true,
-	ValidArgs:             []string{"bash", "zsh"},
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
 	Args:                  cobra.ExactValidArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		switch args[0] {
 		case "bash":
-			cmd.Root().GenBashCompletion(os.Stdout)
+			if file != "" {
+				cmd.Root().GenBashCompletionFile(file)
+			} else {
+				cmd.Root().GenBashCompletion(os.Stdout)
+			}
 		case "zsh":
-			cmd.Root().GenZshCompletion(os.Stdout)
+			if file != "" {
+				cmd.Root().GenZshCompletionFile(file)
+			} else {
+				cmd.Root().GenZshCompletion(os.Stdout)
+			}
+		case "fish":
+			if file != "" {
+				cmd.Root().GenFishCompletionFile(file, true)
+			} else {
+				cmd.Root().GenFishCompletion(os.Stdout, true)
+			}
+		case "powershell":
+			if file != "" {
+				cmd.Root().GenPowerShellCompletionFile(file)
+			} else {
+				cmd.Root().GenPowerShellCompletion(os.Stdout)
+			}
 		}
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,18 +3,28 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
 	"ddbt/bigquery"
 	"ddbt/compiler"
 	"ddbt/config"
+	"ddbt/utils"
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "ddbt",
-	Short: "Dom's Data Build tool is very fast version of DBT",
-	Long:  "DDBT is an experimental drop in replacement for DBT which aims to be much faster at building the DAG for projects with large numbers of models",
+	Use:     "ddbt",
+	Short:   "Dom's Data Build tool is very fast version of DBT",
+	Long:    "DDBT is an experimental drop in replacement for DBT which aims to be much faster at building the DAG for projects with large numbers of models",
+	Version: utils.DdbtVersion,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		// Do not run init if we're running info commands which aren't actually going to execute operate on a project
+		if cmd != versionCmd && cmd.Name() != "help" {
+			initDDBT()
+		}
+	},
 }
 
 var (
@@ -24,8 +34,6 @@ var (
 )
 
 func init() {
-	cobra.OnInitialize(initDDBT)
-
 	rootCmd.PersistentFlags().StringVarP(&targetProfile, "target", "t", "", "Which target profile to use")
 	rootCmd.PersistentFlags().StringVarP(&upstreamProfile, "upstream", "u", "", "Which target profile to use when reading data outside the current DAG")
 	rootCmd.PersistentFlags().IntVar(&threads, "threads", 0, "How many threads to execute with")
@@ -39,6 +47,9 @@ func Execute() {
 }
 
 func initDDBT() {
+	// If you happen to be one folder up from the DBT project, we'll cd in there for you to be nice :)
+	cdIntoDBTFolder()
+
 	// Read the project config
 	cfg, err := config.Read(targetProfile, upstreamProfile, threads, compiler.CompileStringWithCache)
 	if err != nil {
@@ -50,5 +61,21 @@ func initDDBT() {
 	if err := bigquery.Init(cfg); err != nil {
 		fmt.Printf("❌ Unable to init BigQuery: %s\n", err)
 		os.Exit(1)
+	}
+}
+
+func cdIntoDBTFolder() {
+	wd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+
+	if path.Base(wd) != "dbt" {
+		if stat, err := os.Stat(filepath.Join(wd, "dbt")); !os.IsNotExist(err) && stat.IsDir() {
+			err = os.Chdir(filepath.Join(wd, "dbt"))
+			if err != nil {
+				panic(err)
+			}
+		}
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,7 +21,7 @@ var rootCmd = &cobra.Command{
 	Version: utils.DdbtVersion,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		// Do not run init if we're running info commands which aren't actually going to execute operate on a project
-		if cmd != versionCmd && cmd.Name() != "help" {
+		if cmd != versionCmd && cmd != completionCmd && cmd.Name() != "help" {
 			initDDBT()
 		}
 	},

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -20,8 +20,7 @@ var ModelFilter string
 
 func init() {
 	rootCmd.AddCommand(runCmd)
-
-	runCmd.Flags().StringVarP(&ModelFilter, "models", "m", "", "Select which model(s) to run")
+	addModelsFlag(runCmd)
 }
 
 var runCmd = &cobra.Command{
@@ -39,6 +38,14 @@ var runCmd = &cobra.Command{
 			os.Exit(1)
 		}
 	},
+}
+
+func addModelsFlag(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&ModelFilter, "models", "m", "", "Select which model(s) to run")
+	err := cmd.RegisterFlagCompletionFunc("models", completeModelFn)
+	if err != nil {
+		panic(err)
+	}
 }
 
 func compileAllModels() (*fs.FileSystem, *compiler.GlobalContext) {

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -18,7 +18,7 @@ import (
 
 func init() {
 	rootCmd.AddCommand(testCmd)
-	testCmd.Flags().StringVarP(&ModelFilter, "models", "m", "", "Select which model(s) to test")
+	addModelsFlag(testCmd)
 }
 
 var testCmd = &cobra.Command{

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -16,6 +16,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Prints the version of DDBT",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(utils.DdbtVersion)
+		fmt.Println("ddbt version", utils.DdbtVersion)
 	},
 }

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -21,7 +21,8 @@ var skipInitialBuild = false
 
 func init() {
 	rootCmd.AddCommand(watchCmd)
-	watchCmd.Flags().StringVarP(&ModelFilter, "models", "m", "", "Select which model(s) to watch")
+	addModelsFlag(watchCmd)
+
 	watchCmd.Flags().BoolVarP(&skipInitialBuild, "skip-run", "s", false, "Skip the initial execution of the DAG and go straight into watch mode")
 }
 

--- a/utils/version.go
+++ b/utils/version.go
@@ -1,3 +1,3 @@
 package utils
 
-const DdbtVersion = "ddbt v0.1.0 [experimental]"
+const DdbtVersion = "0.1.0"


### PR DESCRIPTION
 - Added support for Fish, Powershell completitions with file writing
 - Added `--version` support as well as `version`
 - Added ability for an automatic CHDIR into a DBT project if you're not
 in one
 - Allowed `version`, `help` and `completion` to be run from outside a
 DBT project folder