### PR TITLE
YAML Schema Reading

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -60,6 +60,7 @@ func compileAllModels() (*fs.FileSystem, *compiler.GlobalContext) {
 
 	// Now parse and compile the whole project
 	parseFiles(fileSystem)
+	parseSchemas(fileSystem)
 	gc := compiler.NewGlobalContext(config.GlobalCfg, fileSystem)
 	compileMacros(fileSystem, gc)
 	compileFiles(fileSystem, gc)
@@ -78,6 +79,26 @@ func parseFiles(fileSystem *fs.FileSystem) {
 			if err := compiler.ParseFile(file); err != nil {
 				pb.Stop()
 				fmt.Printf("❌ Unable to parse %s %s: %s\n", file.Type, file.Name, err)
+				os.Exit(1)
+			}
+			pb.Increment()
+
+			return nil
+		},
+		nil,
+	)
+}
+
+func parseSchemas(fileSystem *fs.FileSystem) {
+	pb := utils.NewProgressBar("🗃 Reading & Parsing Schemas", fileSystem.NumberSchemas())
+	defer pb.Stop()
+
+	_ = fs.ProcessSchemas(
+		fileSystem.AllSchemas(),
+		func(schema *fs.SchemaFile) error {
+			if err := schema.Parse(); err != nil {
+				pb.Stop()
+				fmt.Printf("❌ Unable to parse %s: %s\n", schema.Name, err)
 				os.Exit(1)
 			}
 			pb.Increment()

--- a/fs/file.go
+++ b/fs/file.go
@@ -3,7 +3,6 @@ package fs
 import (
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -50,7 +49,7 @@ type File struct {
 	isInDAG       bool
 }
 
-func newFile(path string, file os.FileInfo, fileType FileType) *File {
+func newFile(path string, fileType FileType) *File {
 	return &File{
 		Type:         fileType,
 		Name:         strings.TrimSuffix(filepath.Base(path), ".sql"),
@@ -63,6 +62,10 @@ func newFile(path string, file os.FileInfo, fileType FileType) *File {
 
 		EphemeralCTES: make(map[string]*File),
 	}
+}
+
+func (f *File) GetName() string {
+	return f.Name
 }
 
 func (f *File) SetConfig(name string, value *compilerInterface.Value) {

--- a/fs/schema.go
+++ b/fs/schema.go
@@ -1,0 +1,49 @@
+package fs
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"ddbt/properties"
+)
+
+type SchemaFile struct {
+	Name       string
+	Path       string
+	Properties *properties.File
+
+	mutex sync.Mutex
+}
+
+func newSchemaFile(path string) *SchemaFile {
+	return &SchemaFile{
+		Name:       strings.TrimSuffix(filepath.Base(path), ".yml"),
+		Path:       path,
+		Properties: &properties.File{},
+	}
+}
+
+func (s *SchemaFile) GetName() string {
+	return s.Name
+}
+
+func (s *SchemaFile) Parse() error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	f, err := os.Open(s.Path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	bytes, err := ioutil.ReadAll(f)
+	if err != nil {
+		return err
+	}
+
+	return s.Properties.Unmarshal(bytes)
+}

--- a/properties/propertiesFile.go
+++ b/properties/propertiesFile.go
@@ -13,6 +13,11 @@ type File struct {
 	Snapshots Models `yaml:"snapshots,omitempty"` // List of the snapshot schemas defined in this file (same structure as a model)
 }
 
+// Unmarshals the file
+func (f *File) Unmarshal(bytes []byte) error {
+	return yaml.Unmarshal(bytes, f)
+}
+
 // The docs struct defines if a schema shows up on the docs server
 type Docs struct {
 	Show *bool `yaml:"show,omitempty"` // If not set, we default to true (but need to track it's not set for when we write YAML back out)

--- a/properties/propertiesFile.go
+++ b/properties/propertiesFile.go
@@ -1,0 +1,65 @@
+package properties
+
+import (
+	"gopkg.in/yaml.v2"
+)
+
+// Represents what can be held within a DBT properties file
+type File struct {
+	Version   int    `yaml:"version"`             // What version of the schema we're on (always 2)
+	Models    Models `yaml:"models,omitempty"`    // List of the model schemas defined in this file
+	Macros    Macros `yaml:"macros,omitempty"`    // List of the macro schemas defined in this file
+	Seeds     Models `yaml:"seeds,omitempty"`     // List of the seed schemas defined in this file (same structure as a model)
+	Snapshots Models `yaml:"snapshots,omitempty"` // List of the snapshot schemas defined in this file (same structure as a model)
+}
+
+// The docs struct defines if a schema shows up on the docs server
+type Docs struct {
+	Show *bool `yaml:"show,omitempty"` // If not set, we default to true (but need to track it's not set for when we write YAML back out)
+}
+
+type Models []Model
+
+// A model/seed/snapshot schema
+type Model struct {
+	Name        string   `yaml:"name"`
+	Description string   `yaml:"description,omitempty"`
+	Docs        Docs     `yaml:"docs,omitempty"`
+	Meta        MetaData `yaml:"meta,omitempty"`
+	Tests       Tests    `yaml:"tests,omitempty"`   // Model level tests
+	Columns     Columns  `yaml:"columns,omitempty"` // Columns
+}
+
+type Columns []Column
+
+// Represents a single column within a Model schema
+type Column struct {
+	Name        string   `yaml:"name"`
+	Description string   `yaml:"description,omitempty"`
+	Meta        MetaData `yaml:"meta,omitempty"`
+	Quote       bool     `yaml:"quote,omitempty"`
+	Tests       Tests    `yaml:"tests,omitempty"`
+	Tags        []string `yaml:"tags,omitempty,flow"`
+}
+
+type Macros []Macro
+
+// A macro schema
+type Macro struct {
+	Name        string         `yaml:"name"`
+	Description string         `yaml:"description,omitempty"`
+	Docs        Docs           `yaml:"docs,omitempty"`
+	Arguments   MacroArguments `yaml:"arguments,omitempty"`
+}
+
+type MacroArguments []MacroArgument
+
+// A single argument on a macro
+type MacroArgument struct {
+	Name        string `yaml:"name"`
+	Type        string `yaml:"type"`
+	Description string `yaml:"description"`
+}
+
+// Metadata that we can store against various parts of the schema
+type MetaData yaml.MapSlice

--- a/properties/propertiesFile_test.go
+++ b/properties/propertiesFile_test.go
@@ -1,0 +1,120 @@
+package properties
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestPropertiesParse(t *testing.T) {
+	yml := `version: 2
+models:
+- name: model_name
+  description: random description
+  docs:
+    show: true
+  meta:
+    test: value
+  tests:
+  - unique:
+      column_name: a || '-' || b
+  columns:
+  - name: column_name
+    description: Test description
+    tests:
+    - not_null
+    tags: ['some:tag', 'tag:2']
+  - name: another_column
+    description: |
+      This is a multi line description!
+    quote: true
+    tests:
+    - accepted_values:
+        values:
+        - foo
+        - bar
+        tags:
+        - a
+        - b
+        - c
+    - relationships:
+        to: ref('another_model')
+        field: id
+    - unique:
+        severity: warn
+- name: another_model
+macros:
+- name: my_macro
+  description: some macro which does stuff
+  docs:
+    show: false
+  arguments:
+  - name: test_arg
+    type: string
+    description: another description block
+  - name: second_arg
+    type: bool
+    description: |
+      Test description 2
+`
+	file := &File{}
+	require.NoError(t, yaml.Unmarshal([]byte(yml), file))
+
+	assert.Equal(t, 2, file.Version)
+	require.Len(t, file.Models, 2, "Invalid number of models")
+
+	assert.Equal(t, "model_name", file.Models[0].Name)
+	assert.Equal(t, "random description", file.Models[0].Description)
+	assert.Equal(t, true, *file.Models[0].Docs.Show)
+
+	require.Len(t, file.Models[0].Tests, 1, "Not enough model level tests")
+	assert.Equal(t, "unique", file.Models[0].Tests[0].Name)
+	assert.Equal(t, "column_name", file.Models[0].Tests[0].Arguments[0].Name)
+	assert.Equal(t, "a || '-' || b", file.Models[0].Tests[0].Arguments[0].Value)
+	assert.Empty(t, file.Models[0].Tests[0].Tags)
+	assert.Empty(t, file.Models[0].Tests[0].Severity)
+
+	require.Len(t, file.Models[0].Columns, 2, "Not enough columns")
+
+	// Test column 1
+	assert.Equal(t, "column_name", file.Models[0].Columns[0].Name)
+	assert.Equal(t, "Test description", file.Models[0].Columns[0].Description)
+	assert.Equal(t, false, file.Models[0].Columns[0].Quote)
+
+	require.Len(t, file.Models[0].Columns[0].Tests, 1, "Not enough tests on the first column")
+	require.Equal(t, "not_null", file.Models[0].Columns[0].Tests[0].Name)
+	assert.Empty(t, file.Models[0].Columns[0].Tests[0].Arguments)
+	assert.Empty(t, file.Models[0].Columns[0].Tests[0].Tags)
+	assert.Empty(t, file.Models[0].Columns[0].Tests[0].Severity)
+
+	// Test column 2
+	assert.Equal(t, "another_column", file.Models[0].Columns[1].Name)
+	assert.Equal(t, "This is a multi line description!\n", file.Models[0].Columns[1].Description)
+	assert.Equal(t, true, file.Models[0].Columns[1].Quote)
+	require.Len(t, file.Models[0].Columns[1].Tests, 3, "Not enough tests on the second column")
+
+	// Test column 2; test 1
+	require.Equal(t, "accepted_values", file.Models[0].Columns[1].Tests[0].Name)
+	assert.Equal(t, TestArguments{TestArgument{"values", []interface{}{"foo", "bar"}}}, file.Models[0].Columns[1].Tests[0].Arguments)
+	assert.Equal(t, []string{"a", "b", "c"}, file.Models[0].Columns[1].Tests[0].Tags)
+	assert.Empty(t, file.Models[0].Columns[1].Tests[0].Severity)
+
+	// Test column 2; test 2
+	require.Equal(t, "relationships", file.Models[0].Columns[1].Tests[1].Name)
+	assert.Equal(t, TestArguments{TestArgument{"to", "ref('another_model')"}, TestArgument{"field", "id"}}, file.Models[0].Columns[1].Tests[1].Arguments)
+	assert.Empty(t, file.Models[0].Columns[1].Tests[1].Tags)
+	assert.Empty(t, file.Models[0].Columns[1].Tests[1].Severity)
+
+	// Test column 2; test 3
+	require.Equal(t, "unique", file.Models[0].Columns[1].Tests[2].Name)
+	assert.Empty(t, file.Models[0].Columns[1].Tests[2].Arguments)
+	assert.Empty(t, file.Models[0].Columns[1].Tests[2].Tags)
+	assert.Equal(t, "warn", file.Models[0].Columns[1].Tests[2].Severity)
+
+	// Test output back
+	bytes, err := yaml.Marshal(file)
+	require.NoError(t, err, "Unable to marshal properties file back to YAML")
+	assert.Equal(t, yml, string(bytes), "Output file didn't match")
+}

--- a/properties/test.go
+++ b/properties/test.go
@@ -1,0 +1,144 @@
+package properties
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+
+	"gopkg.in/yaml.v2"
+)
+
+type Tests []*Test
+
+// Represents a test we should perform against a Model or Column
+//
+// Due to how DBT encodes these within YAML we need to write a custom set
+// of marshallers to ensure we can read/write the YAML files correctly
+//
+// Inside the tests slice the YAML could look like this when there are no other parameters;
+//
+// - test_name
+//
+// or like this, if we need to provide other params;
+//
+// - test_name:
+//     arg1: something
+//     tags: ['a', 'b', 'c']
+type Test struct {
+	Name      string // the name of the inbuilt test we want to run such as "not_null" or "unique"
+	Severity  string // "warn" or "error" are the only allowed values
+	Tags      []string
+	Arguments TestArguments
+}
+
+// The arguments which a test requires
+// Note; we use a slice here to preserve ordering if we are mutating an existing schema file
+// on the filesystem
+type TestArguments []TestArgument
+type TestArgument struct {
+	Name  string
+	Value interface{}
+}
+
+func (o *Test) UnmarshalYAML(unmarshal func(v interface{}) error) error {
+	var m map[string]yaml.MapSlice
+
+	// Handle the case where we just have a test name
+	if err := unmarshal(&m); err != nil {
+		if err2 := unmarshal(&o.Name); err2 == nil {
+			return nil
+		}
+
+		return err
+	}
+
+	// Otherwise we expect a map with a single key - the test name
+	if len(m) != 1 {
+		return errors.New(fmt.Sprintf("expected 1 key for test, got %d", len(m)))
+	}
+
+	// Now read the arguments out in the order they are present
+	for testName, properties := range m {
+		o.Name = testName
+		arguments := make(TestArguments, 0)
+
+		for _, property := range properties {
+			// pull out the severity or tags key to the top level test object
+			switch property.Key {
+			case "severity":
+				switch v := property.Value.(type) {
+				case string:
+					if v != "warn" && v != "error" {
+						return errors.New(fmt.Sprintf("severity expected to be a `warn` or `error`, got %v", v))
+					}
+
+					o.Severity = v
+				default:
+					return errors.New(fmt.Sprintf("severity expected to be a `warn` or `error`, got %v", reflect.TypeOf(v)))
+				}
+
+			case "tags":
+				switch v := property.Value.(type) {
+				case []interface{}:
+					tags := make([]string, 0, len(v))
+
+					for _, tagI := range v {
+						if tag, ok := tagI.(string); ok {
+							tags = append(tags, tag)
+						} else {
+							return errors.New(fmt.Sprintf("expected tag value to be a string, got %v", reflect.TypeOf(tagI)))
+						}
+					}
+
+					o.Tags = tags
+
+				default:
+					return errors.New(fmt.Sprintf("tags expected to be an array, got %v", reflect.TypeOf(v)))
+				}
+
+			default:
+				// otherwise transpose the test arguments to our arguments struct
+				str, ok := property.Key.(string)
+				if !ok {
+					return errors.New(fmt.Sprintf("unable to convert property key to string: %v", property.Key))
+				}
+
+				arguments = append(arguments, TestArgument{
+					Name:  str,
+					Value: property.Value,
+				})
+			}
+		}
+
+		o.Arguments = arguments
+	}
+
+	return nil
+}
+
+func (o *Test) MarshalYAML() (interface{}, error) {
+	if len(o.Arguments) == 0 && len(o.Tags) == 0 && o.Severity == "" {
+		return o.Name, nil
+	}
+
+	args := make(yaml.MapSlice, 0)
+
+	// Write the arguments back out to a MapSlice (to preserve ordering)
+	for _, arg := range o.Arguments {
+		args = append(args, yaml.MapItem{Key: arg.Name, Value: arg.Value})
+	}
+
+	// Append our tags
+	if len(o.Tags) > 0 {
+		args = append(args, yaml.MapItem{Key: "tags", Value: o.Tags})
+	}
+
+	// Append the Severity
+	if o.Severity != "" {
+		args = append(args, yaml.MapItem{Key: "severity", Value: o.Severity})
+	}
+
+	return yaml.MapSlice{
+		{Key: o.Name, Value: args},
+	}, nil
+}


### PR DESCRIPTION
This PR adds the ability for DDBT to read the yaml based schema files off the filesystem and ensures it can parse all of them for a given project.

It does not yet use the information it finds within those schema files.