### PR TITLE
Model filter completion

### DIFF
--- a/cmd/model_completion.go
+++ b/cmd/model_completion.go
@@ -25,9 +25,7 @@ func completeModelFn(cmd *cobra.Command, args []string, toComplete string) ([]st
 	return matchModel(toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
-// matchModel returns a list of models with the given prefix.
-// If prefix is empty, it returns all models.
-func matchModel(prefix string) []string {
+func getFileSystem() *fs.FileSystem {
 	readFSOnce.Do(func() {
 		// Read filesystem w/o output as it'll interfere with autocompletion
 		fileSystem, err := fs.ReadFileSystem(ioutil.Discard)
@@ -36,9 +34,16 @@ func matchModel(prefix string) []string {
 		}
 		cachedFS = fileSystem
 	})
-	if cachedFS != nil {
-		matched := make([]string, 0, len(cachedFS.Models()))
-		for _, m := range cachedFS.Models() {
+	return cachedFS
+}
+
+// matchModel returns a list of models with the given prefix.
+// If prefix is empty, it returns all models.
+func matchModel(prefix string) []string {
+	fileSys := getFileSystem()
+	if fileSys != nil {
+		matched := make([]string, 0, len(fileSys.Models()))
+		for _, m := range fileSys.Models() {
 			if strings.HasPrefix(m.Name, prefix) {
 				// Include as suggestion:
 				//   model_name -- full/path/to/model_name.sql

--- a/cmd/model_completion.go
+++ b/cmd/model_completion.go
@@ -3,9 +3,12 @@ package cmd
 import (
 	"fmt"
 	"io/ioutil"
+	"sort"
 	"strings"
 	"sync"
 
+	"ddbt/compiler"
+	"ddbt/config"
 	"ddbt/fs"
 
 	"github.com/spf13/cobra"
@@ -22,6 +25,29 @@ func completeModelFn(cmd *cobra.Command, args []string, toComplete string) ([]st
 		// Only complete the first arg.
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
+	return matchModel(toComplete), cobra.ShellCompDirectiveNoFileComp
+}
+
+// completeModelFilterFn is a custom valid argument function for cobra.Command.
+// It is a variation of completeModelFn, but supports model filters
+// (e.g. specifying upstream with + or with tags)
+func completeModelFilterFn(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		// Only complete the first arg.
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	switch {
+	case strings.HasPrefix(toComplete, "tag:"): // try to match tag:key=value
+		return matchTag(toComplete[4:]), cobra.ShellCompDirectiveNoFileComp
+	case strings.HasPrefix(toComplete, "+"): //  try to match +model_name
+		models := matchModel(toComplete[1:])
+		suggestion := make([]string, 0, len(models))
+		for _, m := range models {
+			suggestion = append(suggestion, "+"+m)
+		}
+		return suggestion, cobra.ShellCompDirectiveNoFileComp
+	}
+	// Normal model matching
 	return matchModel(toComplete), cobra.ShellCompDirectiveNoFileComp
 }
 
@@ -53,4 +79,53 @@ func matchModel(prefix string) []string {
 		return matched
 	}
 	return nil // Nothing matched
+}
+
+// matchModel returns a list of tags with the given prefix.
+// If prefix is empty, it returns all tags.
+// A tag is in the format of key=value.
+func matchTag(prefix string) []string {
+	fileSys := getFileSystem()
+	if fileSys != nil {
+		tags := getAllTags(fileSys)
+		var matched []string
+		for tagName, files := range tags {
+			if strings.HasPrefix(tagName, prefix) {
+				// Include as suggestion:
+				//   tag:key=value -- Matches N models
+				matched = append(matched, fmt.Sprintf("tag:%s\tMatches %d models", tagName, len(files)))
+			}
+		}
+		// Sort output so consecutive autocompletes suggestions are stable
+		sort.Strings(matched)
+		return matched
+	}
+	return nil
+}
+
+// getAllTags reads all the tags on models.
+func getAllTags(fileSys *fs.FileSystem) map[string][]string {
+	if fileSys != nil {
+		tags := make(map[string][]string)
+		// This is simplified version of compileAllModels() to read all tags
+		// from the models.
+		for _, f := range fileSys.AllFiles() {
+			if err := compiler.ParseFile(f); err != nil {
+				cobra.CompError(fmt.Sprintf("❌ Unable to parse file %s: %s\n", f.Path, err))
+				continue
+			}
+		}
+		gc := compiler.NewGlobalContext(config.GlobalCfg, fileSys)
+		for _, f := range append(fileSys.Macros(), fileSys.Models()...) {
+			if err := compiler.CompileModel(f, gc, false); err != nil {
+				cobra.CompError(fmt.Sprintf("❌ Unable to compile file %s: %s\n", f.Path, err))
+				continue
+			}
+			for _, tag := range f.GetTags() {
+				tags[tag] = append(tags[tag], f.Name)
+			}
+		}
+		return tags
+	}
+	return nil
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -42,7 +42,7 @@ var runCmd = &cobra.Command{
 
 func addModelsFlag(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&ModelFilter, "models", "m", "", "Select which model(s) to run")
-	err := cmd.RegisterFlagCompletionFunc("models", completeModelFn)
+	err := cmd.RegisterFlagCompletionFunc("models", completeModelFilterFn)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Follow up on #4.

This PR adds model filter autocomplete.
In addition to `ddbt run -m model_na[tab][tab]` (completes a `ddbt run -m model_name`, also support other formats of model filtering supported by [d]dbt:
- `ddbt run -m +model_na[tab][tab]` gives `ddbt run -m +model_name` suggestions
- `ddbt run -m tag:mo[tab][tab]` gives `ddbt run -m tag:model_group=xyz` suggestions

Making the autocomplete feature parity with dbt