### PR TITLE
Configuration parsing

### DIFF
--- a/bigquery/executor.go
+++ b/bigquery/executor.go
@@ -366,10 +366,10 @@ func LoadSeedFile(ctx context.Context, seed *fs.SeedFile) error {
 func getSeedSchema(seed *fs.SeedFile) (bigquery.Schema, error) {
 	schema := make([]*bigquery.FieldSchema, 0, len(seed.Columns))
 	// Use schema specified column types if available
-	for column, colType := range seed.ColumnTypes {
+	for _, column := range seed.Columns {
 		schema = append(schema, &bigquery.FieldSchema{
 			Name: column,
-			Type: bigquery.FieldType(strings.ToUpper(colType)),
+			Type: bigquery.FieldType(strings.ToUpper(seed.ColumnTypes[column])),
 		})
 	}
 	return schema, nil

--- a/config/config.go
+++ b/config/config.go
@@ -132,9 +132,11 @@ func Read(targetProfile string, upstreamProfile string, threads int, strExecutor
 	if seedCfg, found := project.Seeds[project.Name]; found {
 		cfg, err := readSeedCfg(seedCfg)
 		if err != nil {
-			return nil, err
+			// if parsing of seed section of config has failed, don't error
+			fmt.Fprintf(os.Stderr, "⚠️ Cannot parse seed config: %v\n", err)
+		} else {
+			GlobalCfg.seedConfig = cfg
 		}
-		GlobalCfg.seedConfig = cfg
 	}
 
 	return GlobalCfg, nil

--- a/config/modelConfig.go
+++ b/config/modelConfig.go
@@ -21,6 +21,7 @@ type ModelConfig struct {
 // https://docs.getdbt.com/reference/model-configs#general-configurations
 type GeneralConfig struct {
 	Enabled     bool
+	Schema      string
 	Tags        []string
 	PreHooks    []string
 	PostHooks   []string
@@ -212,10 +213,11 @@ func readGeneralConfig(
 			}
 
 		case "schema":
-			_, err := asStr("schema", value, strExecutor)
+			schema, err := asStr("schema", value, strExecutor)
 			if err != nil {
 				return nil, err
 			}
+			config.Schema = schema
 
 		case "alias":
 

--- a/config/modelConfig.go
+++ b/config/modelConfig.go
@@ -8,23 +8,36 @@ import (
 	"strings"
 )
 
+// ModelConfig represents model configurations.
+//
+// https://docs.getdbt.com/reference/model-configs
 type ModelConfig struct {
-	Enabled      bool
-	Tags         []string
-	PreHooks     []string
-	PostHooks    []string
+	GeneralConfig
 	Materialized string
-	PersistDocs  struct {
+}
+
+// GeneralConfig represents common 'general' configurations.
+//
+// https://docs.getdbt.com/reference/model-configs#general-configurations
+type GeneralConfig struct {
+	Enabled     bool
+	Tags        []string
+	PreHooks    []string
+	PostHooks   []string
+	PersistDocs struct {
 		Relation bool
 		Columns  bool
 	}
+	FullRefresh bool
 }
 
 var defaultConfig = ModelConfig{
-	Enabled:      true,
-	Tags:         []string{},
-	PreHooks:     []string{},
-	PostHooks:    []string{},
+	GeneralConfig: GeneralConfig{
+		Enabled:   true,
+		Tags:      []string{},
+		PreHooks:  []string{},
+		PostHooks: []string{},
+	},
 	Materialized: "table",
 }
 
@@ -60,50 +73,14 @@ func readGeneralFolderBasedConfig(m map[string]interface{}, strExecutor func(s s
 func readSubFolder(folderName string, config ModelConfig, m map[string]interface{}, strExecutor func(s string) (string, error)) error {
 	subFolders := make(map[string]map[string]interface{})
 
-	for key, value := range m {
+	// Read common 'general' configurations.
+	remaining, err := readGeneralConfig(&config.GeneralConfig, m, strExecutor)
+	if err != nil {
+		return err
+	}
+
+	for key, value := range remaining {
 		switch key {
-		case "enabled":
-			if b, ok := value.(bool); ok {
-				config.Enabled = b
-			} else {
-				return errors.New(fmt.Sprintf("Unable to convert `enabled` to boolean, got: %v", reflect.TypeOf(value)))
-			}
-
-		case "tags":
-			list, err := strOrList("tags", value, strExecutor)
-			if err != nil {
-				return err
-			}
-			config.Tags = list
-
-		case "pre_hook":
-			list, err := strOrList("pre_hook", value, strExecutor)
-			if err != nil {
-				return err
-			}
-			config.PreHooks = list
-
-		case "post_hook":
-			list, err := strOrList("post_hook", value, strExecutor)
-			if err != nil {
-				return err
-			}
-			config.PostHooks = list
-
-		case "database":
-			_, err := asStr("database", value, strExecutor)
-			if err != nil {
-				return err
-			}
-
-		case "schema":
-			_, err := asStr("schema", value, strExecutor)
-			if err != nil {
-				return err
-			}
-
-		case "persist_docs":
-
 		case "materialized":
 			materialized, err := asStr("materialized", value, strExecutor)
 			if err != nil {
@@ -182,4 +159,84 @@ func asStr(name string, value interface{}, strExecutor func(s string) (string, e
 	}
 
 	return strValue, nil
+}
+
+// readGeneralConfig reads and consumes common 'general configurations'
+// config keys and return all the remaining key/value (or error).
+//
+// https://docs.getdbt.com/reference/model-configs#general-configurations
+func readGeneralConfig(
+	config *GeneralConfig,
+	m map[string]interface{},
+	strExecutor func(s string) (string, error),
+) (map[string]interface{}, error) {
+	if config == nil {
+		return nil, fmt.Errorf("General config is not writable")
+	}
+
+	var remaining map[string]interface{}
+	for key, value := range m {
+		switch key {
+		case "enabled":
+			if b, ok := value.(bool); ok {
+				config.Enabled = b
+			} else {
+				return nil, fmt.Errorf("Unable to convert `enabled` to boolean, got: %v", reflect.TypeOf(value))
+			}
+
+		case "tags":
+			list, err := strOrList("tags", value, strExecutor)
+			if err != nil {
+				return nil, err
+			}
+			config.Tags = list
+
+		case "pre_hook":
+			list, err := strOrList("pre_hook", value, strExecutor)
+			if err != nil {
+				return nil, err
+			}
+			config.PreHooks = list
+
+		case "post_hook":
+			list, err := strOrList("post_hook", value, strExecutor)
+			if err != nil {
+				return nil, err
+			}
+			config.PostHooks = list
+
+		case "database":
+			_, err := asStr("database", value, strExecutor)
+			if err != nil {
+				return nil, err
+			}
+
+		case "schema":
+			_, err := asStr("schema", value, strExecutor)
+			if err != nil {
+				return nil, err
+			}
+
+		case "alias":
+
+		case "persist_docs":
+
+		case "full_refresh":
+			if b, ok := value.(bool); ok {
+				config.FullRefresh = b
+			} else {
+				return nil, fmt.Errorf("Unable to convert `full_refresh` to boolean, got: %v", reflect.TypeOf(value))
+			}
+
+		default:
+			// For any key not part of general configurations,
+			// copy to remaining to be processed later.
+			if remaining == nil {
+				remaining = make(map[string]interface{})
+			}
+			remaining[key] = value
+		}
+	}
+
+	return remaining, nil
 }

--- a/config/modelConfig_test.go
+++ b/config/modelConfig_test.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestModelConfig(t *testing.T) {
+	dbtProjectYml := `
+name: package_name
+version: '1.0'
+
+profile: ddbt
+models:
+  ddbt:
+    enabled: true
+    schema: default_dataset_name
+    tags: ["tag_one", "tag_two"]
+    materialized: ephemeral
+    table_name:
+      tags: # General Config
+        - tag_two
+        - tag_three
+      materialized: table # Model config
+    another_table_name:
+      tags: []
+`
+
+	var project dbtProject
+	require.NoError(t, yaml.Unmarshal([]byte(dbtProjectYml), &project))
+	err := readGeneralFolderBasedConfig(project.Models["ddbt"], func(s string) (string, error) { return s, nil })
+	require.NoError(t, err)
+
+	assert.NotNil(t, folderBasedConfig["models/"])
+	assert.Equal(t, []string{"tag_one", "tag_two"}, folderBasedConfig["models/"].Tags)
+	assert.Equal(t, "ephemeral", folderBasedConfig["models/"].Materialized)
+
+	// Override parent materialized
+	assert.NotNil(t, folderBasedConfig["models/table_name/"])
+	assert.Equal(t, []string{"tag_two", "tag_three"}, folderBasedConfig["models/table_name/"].Tags)
+	assert.Equal(t, "table", folderBasedConfig["models/table_name/"].Materialized)
+
+	// Inherit materialized from parent
+	assert.NotNil(t, folderBasedConfig["models/another_table_name/"])
+	assert.Equal(t, []string(nil), folderBasedConfig["models/another_table_name"].Tags)
+	assert.Equal(t, "ephemeral", folderBasedConfig["models/another_table_name/"].Materialized)
+}

--- a/config/seedConfig_test.go
+++ b/config/seedConfig_test.go
@@ -1,0 +1,98 @@
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSeedConfig(t *testing.T) {
+	dbtProjectYml := `
+name: package_name
+version: '1.0'
+
+profile: ddbt
+seeds:
+  ddbt:
+    enabled: true
+    schema: default_dataset_name
+    table_name:
+      column_types:
+        id: string
+        amount: numeric
+        description: string
+      subfolder_table_name:
+        column_types:
+          extra_field: string
+`
+
+	var project dbtProject
+	require.NoError(t, yaml.Unmarshal([]byte(dbtProjectYml), &project))
+	seedCfg, err := readSeedCfg(project.Seeds["ddbt"])
+	require.NoError(t, err)
+
+	assert.NotNil(t, seedCfg["data/table_name"])
+	assert.Equal(t, map[string]string{"id": "string", "amount": "numeric", "description": "string"}, seedCfg["data/table_name"].ColumnTypes)
+
+	assert.NotNil(t, seedCfg["data/table_name/subfolder_table_name"])
+	assert.Equal(t, map[string]string{"extra_field": "string"}, seedCfg["data/table_name/subfolder_table_name"].ColumnTypes)
+}
+
+func TestSeedConfigParsing(t *testing.T) {
+	// Valid examples from docs.getdbt.com
+	tcs := [...]struct {
+		name          string
+		dbtProjectYml string
+	}{
+		{
+			name: "Apply the schema configuration to all seeds in your project",
+			dbtProjectYml: `
+seeds:
+  jaffle_shop:
+    schema: seed_data
+`,
+		},
+		{
+			name: "Apply the schema configuration to one seed only",
+			dbtProjectYml: `
+seeds:
+  jaffle_shop:
+    marketing:
+      utm_parameters:
+        schema: seed_data
+`,
+		},
+		{
+			name: "Example seed configuration",
+			dbtProjectYml: `
+name: jaffle_shop
+
+seeds:
+  jaffle_shop:
+    enabled: true
+    schema: seed_data
+    # This configures data/country_codes.csv
+    country_codes:
+      # Override column types
+      column_types:
+        country_code: varchar(2)
+        country_name: varchar(32)
+    marketing:
+      schema: marketing # this will take precedence
+`,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			var project dbtProject
+			require.NoError(t, yaml.Unmarshal([]byte(tc.dbtProjectYml), &project))
+			_, err := readSeedCfg(project.Seeds["jaffle_shop"])
+			require.NoError(t, err)
+		})
+	}
+
+}

--- a/fs/filesystem.go
+++ b/fs/filesystem.go
@@ -187,6 +187,13 @@ func (fs *FileSystem) mapMacroLookupOptions(file *File) error {
 }
 
 func (fs *FileSystem) scanSeedDirectory(path string) error {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			// Return early if seed directory doesn't exist.
+			return nil
+		}
+		return err
+	}
 	return filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
 		// If we've encountered an error walking this path, let's return now
 		if err != nil {

--- a/fs/seed.go
+++ b/fs/seed.go
@@ -81,7 +81,7 @@ func (s *SeedFile) readColumnTypes() error {
 	for _, column := range s.Columns {
 		colType, ok := cfg.ColumnTypes[column]
 		if !ok || colType == "" {
-			return fmt.Errorf("No column type specified for %s column `%s`", s.Path, column)
+			colType = "string" // default to string
 		}
 		if s.ColumnTypes == nil {
 			s.ColumnTypes = make(map[string]string)

--- a/fs/seed.go
+++ b/fs/seed.go
@@ -31,8 +31,17 @@ func (s *SeedFile) GetName() string {
 }
 
 func (s *SeedFile) GetTarget() (*config.Target, error) {
-	// No target overrides
-	return config.GlobalCfg.GetTargetFor(s.Path), nil
+	target := config.GlobalCfg.GetTargetFor(s.Path)
+	seedCfg, err := s.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	// Override dataset from config
+	if seedCfg.Schema != "" {
+		target.DataSet = seedCfg.Schema
+	}
+	return target, nil
 }
 
 func (s *SeedFile) GetConfig() (*config.SeedConfig, error) {

--- a/utils/ProgressBar.go
+++ b/utils/ProgressBar.go
@@ -24,13 +24,12 @@ const (
 )
 
 type ProgressBar struct {
-	label             string
-	completedItems    uint32
-	numberItems       uint32
-	output            io.Writer
-	startTime         time.Time
-	lastIncrementedMu sync.Mutex // prevent concurrent write to lastIncremented
-	lastIncremented   time.Time
+	label           string
+	completedItems  uint32
+	numberItems     uint32
+	output          io.Writer
+	startTime       time.Time
+	lastIncremented time.Time
 
 	started         bool
 	startMutex      sync.Mutex
@@ -65,9 +64,7 @@ func NewProgressBar(label string, numberItems int) *ProgressBar {
 
 func (pb *ProgressBar) Increment() {
 	atomic.AddUint32(&pb.completedItems, 1)
-	pb.lastIncrementedMu.Lock()
 	pb.lastIncremented = time.Now() // don't care about raising sets here, it's only for a rough guess of how fast we are
-	pb.lastIncrementedMu.Unlock()
 }
 
 func (pb *ProgressBar) Width() int {


### PR DESCRIPTION
Addresses bugs due to #13
- Valid seed configuration might not parsed because some common fields from general configuration (e.g. `enabled`) are not properly supported
    - 🏗️  Extract common '[general configuration](https://docs.getdbt.com/reference/model-configs/#general-configurations)' parsing to be reused between models and seed config 28f514c cbfeff8
    - 🧪  Adds some configuration sample and parsing tests ea607cb
- Adds some resiliency when seed configuration cannot be parsed: they are not essential so warn instead of failing completely 
    - ⚠️  Warn but don't fail if seed configuration cannot be parsed 5412a34

Other minor bugfixes
  - 🔀  Makes sure bigquery column types schema are supplied in the same order as seed columns (not map-order) 5fd1d4d


