### PR TITLE
Fix/unionalltables

### DIFF
--- a/compiler/dbtUtils/replacements.go
+++ b/compiler/dbtUtils/replacements.go
@@ -20,7 +20,7 @@ func UnionAllTables(ec compilerInterface.ExecutionContext, caller compilerInterf
 	}
 
 	var builder strings.Builder
-	builder.WriteRune("(")
+	builder.WriteRune('(')
 	for i, table := range args[0].ListValue {
 		if i > 0 {
 			builder.WriteString(" UNION ALL \n")
@@ -40,7 +40,7 @@ func UnionAllTables(ec compilerInterface.ExecutionContext, caller compilerInterf
 		builder.WriteString(table.AsStringValue())
 		builder.WriteRune(')')
 	}
-	builder.WriteRune(")")
+	builder.WriteRune(')')
 	return compilerInterface.NewString(builder.String()), nil
 }
 

--- a/compiler/dbtUtils/replacements.go
+++ b/compiler/dbtUtils/replacements.go
@@ -20,7 +20,7 @@ func UnionAllTables(ec compilerInterface.ExecutionContext, caller compilerInterf
 	}
 
 	var builder strings.Builder
-	builder.WriteString(" ( ")
+	builder.WriteRune("(")
 	for i, table := range args[0].ListValue {
 		if i > 0 {
 			builder.WriteString(" UNION ALL \n")
@@ -40,7 +40,7 @@ func UnionAllTables(ec compilerInterface.ExecutionContext, caller compilerInterf
 		builder.WriteString(table.AsStringValue())
 		builder.WriteRune(')')
 	}
-	builder.WriteString(" ) ")
+	builder.WriteRune(")")
 	return compilerInterface.NewString(builder.String()), nil
 }
 

--- a/compiler/dbtUtils/replacements.go
+++ b/compiler/dbtUtils/replacements.go
@@ -20,7 +20,7 @@ func UnionAllTables(ec compilerInterface.ExecutionContext, caller compilerInterf
 	}
 
 	var builder strings.Builder
-
+	builder.WriteString(" ( ")
 	for i, table := range args[0].ListValue {
 		if i > 0 {
 			builder.WriteString(" UNION ALL \n")
@@ -40,7 +40,7 @@ func UnionAllTables(ec compilerInterface.ExecutionContext, caller compilerInterf
 		builder.WriteString(table.AsStringValue())
 		builder.WriteRune(')')
 	}
-
+	builder.WriteString(" ) ")
 	return compilerInterface.NewString(builder.String()), nil
 }
 


### PR DESCRIPTION
Currently the UnionAllTables replacement is creating the following SQL type: 

  ```
SELECT
*

FROM
(
  SELECT  ...
)
UNION ALL
(
  SELECT  ...       
)
  ...
  ```
which is not SQL friendly in BigQuery, as union tables need to be enclosed between parentheses.
![image](https://user-images.githubusercontent.com/75082703/103666944-312d1600-4f6d-11eb-8344-3697e2a17b6f.png)

  ```
SELECT
*

FROM
((
  SELECT  ...
)
UNION ALL
(
  SELECT  ...       
))
  ...
  ```
![image](https://user-images.githubusercontent.com/75082703/103667615-11e2b880-4f6e-11eb-9682-e0e5fa6d8784.png)

