### PR TITLE
increment ddbt version

### DIFF
--- a/utils/version.go
+++ b/utils/version.go
@@ -1,3 +1,3 @@
 package utils
 
-const DdbtVersion = "0.3.0"
+const DdbtVersion = "0.4.0"


### PR DESCRIPTION
Increment the ddbt version to 0.4.0 after the merge of the schema-gen cmd feature