### PR TITLE
Multiple model selectors

### DIFF
--- a/cmd/isolateDAG.go
+++ b/cmd/isolateDAG.go
@@ -25,8 +25,8 @@ var isolateDAG = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		fileSystem, _ := compileAllModels()
 
-		graph := buildGraph(fileSystem, ModelFilter) // Build the execution graph for the given command
-		graph.AddReferencingTests()                  // And then add any tests which reference that graph
+		graph := buildGraph(fileSystem, ModelFilters) // Build the execution graph for the given command
+		graph.AddReferencingTests()                   // And then add any tests which reference that graph
 
 		if err := graph.AddAllUsedMacros(); err != nil {
 			fmt.Printf("❌ Unable to get all used macros: %s\n", err)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -261,7 +261,7 @@ func buildGraph(fileSystem *fs.FileSystem, modelFilters []string) *fs.Graph {
 	} else {
 		if err := graph.AddAllModels(fileSystem); err != nil {
 			pb.Stop()
-			fmt.Printf("❌ %s\n", modelFilters)
+			fmt.Printf("❌ %s\n", strings.Join(modelFilters, ", "))
 			os.Exit(1)
 		}
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -235,7 +235,7 @@ func buildGraph(fileSystem *fs.FileSystem, modelFilters []string) *fs.Graph {
 				model := fileSystem.Model(modelFilter)
 				if model == nil {
 					pb.Stop()
-					fmt.Printf("❌ Unable to find model: %s\n", modelFilters)
+					fmt.Printf("❌ Unable to find model: %s\n", strings.Join(modelFilters, ", "))
 					os.Exit(1)
 				}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -269,7 +269,7 @@ func buildGraph(fileSystem *fs.FileSystem, modelFilters []string) *fs.Graph {
 	pb.Increment()
 
 	if graph.Len() == 0 {
-		fmt.Printf("❌ Empty DAG generated for model filter: %s\n", modelFilters)
+		fmt.Printf("❌ Empty DAG generated for model filter: %s\n", strings.Join(modelFilters, ", "))
 		os.Exit(1)
 	}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -43,7 +43,7 @@ var runCmd = &cobra.Command{
 }
 
 func addModelsFlag(cmd *cobra.Command) {
-	cmd.Flags().StringSliceVarP(&ModelFilters, "models", "m", []string{}, "Select which model(s) to run")
+	cmd.Flags().StringArrayVarP(&ModelFilters, "models", "m", []string{}, "Select which model(s) to run")
 	err := cmd.RegisterFlagCompletionFunc("models", completeModelFilterFn)
 	if err != nil {
 		panic(err)
@@ -224,7 +224,7 @@ func buildGraph(fileSystem *fs.FileSystem, modelFilters []string) *fs.Graph {
 				// Check if we want all upstreams
 				allUpstreams := modelFilter[0] == '+'
 				if allUpstreams {
-					modelFilters = modelFilters[1:]
+					modelFilter = modelFilter[1:]
 				}
 
 				allDownstreams := modelFilter[len(modelFilter)-1] == '+'

--- a/cmd/showDAG.go
+++ b/cmd/showDAG.go
@@ -22,7 +22,7 @@ var showDAG = &cobra.Command{
 		fileSystem, _ := compileAllModels()
 
 		// If we've been given a model to run, run it
-		graph := buildGraph(fileSystem, ModelFilter)
+		graph := buildGraph(fileSystem, ModelFilters)
 
 		printGraph(graph)
 	},

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -31,7 +31,7 @@ var testCmd = &cobra.Command{
 		fileSystem, globalContext := compileAllModels()
 
 		// If we've been given a model to run, run it
-		graph := buildGraph(fileSystem, ModelFilter)
+		graph := buildGraph(fileSystem, ModelFilters)
 
 		// Add all tests which reference the graph
 		tests := graph.AddReferencingTests()

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -34,7 +34,7 @@ var watchCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		// Do the initial build of the models and then add the tests
 		fileSystem, gc := compileAllModels()
-		graph := buildGraph(fileSystem, ModelFilter)
+		graph := buildGraph(fileSystem, ModelFilters)
 		testsToRun := graph.AddReferencingTests()
 
 		if !skipInitialBuild {

--- a/utils/version.go
+++ b/utils/version.go
@@ -1,3 +1,3 @@
 package utils
 
-const DdbtVersion = "0.4.2"
+const DdbtVersion = "0.4.3"


### PR DESCRIPTION
[Notion Issue
](https://www.notion.so/monzo/Multiple-model-selectors-in-a-single-command-1aae6b7942cb413f99b4f84ffab18766)
Allow multiple model selectors to be passed to ddbt commands; this is crucial for utilising ddbt in our automated pipelines.

I could only get:
```
ddbt <cmd> -m model1 -m +model2
```
to work, and not:
```
ddbt <cmd> -m model1 +model2
```

**If there's a straightforward way to implement the latter then please point me in the right direction!**