### PR TITLE
Include sampling macro in isolate DAG environment

### DIFF
--- a/cmd/isolateDAG.go
+++ b/cmd/isolateDAG.go
@@ -144,6 +144,7 @@ func isolateGraph(graph *fs.Graph) {
 		"debug",
 		"docs",
 		"dbt_modules",
+		"macros/sampling.sql",
 	}
 
 	// If we have a model groups file bring that too

--- a/cmd/isolateDAG.go
+++ b/cmd/isolateDAG.go
@@ -28,10 +28,14 @@ var isolateDAG = &cobra.Command{
 		graph := buildGraph(fileSystem, ModelFilters) // Build the execution graph for the given command
 		graph.AddReferencingTests()                   // And then add any tests which reference that graph
 
-		if err := graph.AddAllUsedMacros(); err != nil {
-			fmt.Printf("❌ Unable to get all used macros: %s\n", err)
-			os.Exit(1)
-		}
+		// Currently ddbt doesn't use dbt materializations. dbt materializations contain macros.
+		// If one needs to override a macro used in a dbt materialization, isolate-dag will not bring the
+		// macro into the new isolated environment. Instead, we (as a temporary workaround) copy over the
+		// whole macros directory.
+		//if err := graph.AddAllUsedMacros(); err != nil {
+		//	fmt.Printf("❌ Unable to get all used macros: %s\n", err)
+		//	os.Exit(1)
+		//}
 
 		isolateGraph(graph)
 	},
@@ -144,7 +148,7 @@ func isolateGraph(graph *fs.Graph) {
 		"debug",
 		"docs",
 		"dbt_modules",
-		"macros/sampling.sql",
+		"macros",
 	}
 
 	// If we have a model groups file bring that too

--- a/utils/version.go
+++ b/utils/version.go
@@ -1,3 +1,3 @@
 package utils
 
-const DdbtVersion = "0.4.4"
+const DdbtVersion = "0.4.5"


### PR DESCRIPTION
We are changing the sampling implementation in dbt to work for all tables instead of base tables only: https://github.com/monzo/analytics/pull/11374

To implement this we have overridden the `create_table_as` macro which is called by the bigquery `table` materialization defined in the dbt-bigquery plugin. 

ddbt doesn't appear to be aware of macros that are used by materializations, so it doesn't copy the `sampling.sql` macro over when running the isolate command. 

This change copies the file explicitly. 