### PR TITLE
Models flag for schema-gen

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ ddbt version 0.2.1
 - `ddbt watch --skip-run` is the same as watch, but will skip the initial run (preventing you having to wait for all the models to run) before running the tests and starting to watch your file system.
 - `ddbt completion zsh` will generate a shell completion script zsh (or bash if you pass that as argument). Detailed steps to set up the completion script can be found in `ddbt completion --help`
 - `ddbt isolate-dag` will create a temporary directory and symlink in all files needed for the given _model_filter_ such that Fishtown's DBT could be run against it without having to be run against every model in your data warehouse
-- `ddbt schema-gen -m my_model` will output a new or updated schema yml file for the model provided in the same directory as the dbt model file. (Note: this currently only support a single model)
+- `ddbt schema-gen -m my_model` will output a new or updated schema yml file for the model provided in the same directory as the dbt model file.
 
 ### Global Arguments
 - `--models model_filter` _or_ `-m model_filter`: Instead of running for every model in your project, DDBT will only execute against the requested models. See filters below for what is accepted for `my_model`

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ ddbt version 0.2.1
 - `ddbt watch --skip-run` is the same as watch, but will skip the initial run (preventing you having to wait for all the models to run) before running the tests and starting to watch your file system.
 - `ddbt completion zsh` will generate a shell completion script zsh (or bash if you pass that as argument). Detailed steps to set up the completion script can be found in `ddbt completion --help`
 - `ddbt isolate-dag` will create a temporary directory and symlink in all files needed for the given _model_filter_ such that Fishtown's DBT could be run against it without having to be run against every model in your data warehouse
-- `ddbt schema-gen my_model` will output a new or updated schema yml file for the model provided in the same directory as the dbt model file. (Note: this does not currenly support the `-m` flag for model dependencies)
+- `ddbt schema-gen -m my_model` will output a new or updated schema yml file for the model provided in the same directory as the dbt model file. (Note: this currently only support a single model)
 
 ### Global Arguments
 - `--models model_filter` _or_ `-m model_filter`: Instead of running for every model in your project, DDBT will only execute against the requested models. See filters below for what is accepted for `my_model`

--- a/bigquery/executor.go
+++ b/bigquery/executor.go
@@ -227,9 +227,7 @@ func NumberRows(query string, target *config.Target) (uint64, error) {
 	return itr.TotalRows, nil
 }
 
-func GetRows(query string, target *config.Target) ([][]Value, Schema, error) {
-	ctx := context.Background()
-
+func GetRows(ctx context.Context, query string, target *config.Target) ([][]Value, Schema, error) {
 	switch {
 	case target.ProjectID == "":
 		return nil, nil, errors.New("no project ID defined to run query against")
@@ -291,8 +289,14 @@ func GetRows(query string, target *config.Target) ([][]Value, Schema, error) {
 	return rows, schema, nil
 }
 
+// GetColumnsFromTable is a fallback GetColumnsFromTableWithContext
+// with a background context.
 func GetColumnsFromTable(table string, target *config.Target) (Schema, error) {
-	_, schema, err := GetRows(fmt.Sprintf("SELECT * FROM %s LIMIT 0", table), target)
+	return GetColumnsFromTableWithContext(context.Background(), table, target)
+}
+
+func GetColumnsFromTableWithContext(ctx context.Context, table string, target *config.Target) (Schema, error) {
+	_, schema, err := GetRows(ctx, fmt.Sprintf("SELECT * FROM %s LIMIT 0", table), target)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/schema_gen.go
+++ b/cmd/schema_gen.go
@@ -58,6 +58,10 @@ func generateSchemaForModel(modelName string) error {
 	fileSystem, _ := compileAllModels()
 
 	model := fileSystem.Model(modelName)
+	if model == nil {
+		fmt.Println("could not load model from file system:", modelName)
+		return fmt.Errorf("Model not found: %s", modelName)
+	}
 
 	target, err := model.GetTarget()
 	if err != nil {

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -45,7 +45,7 @@ var testCmd = &cobra.Command{
 func executeTests(tests []*fs.File, globalContext *compiler.GlobalContext, graph *fs.Graph) bool {
 	pb := utils.NewProgressBar("🔬 Running Tests", len(tests))
 
-	_, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
 
 	var m sync.Mutex
 	widestTestName := 0
@@ -87,7 +87,7 @@ func executeTests(tests []*fs.File, globalContext *compiler.GlobalContext, graph
 					// schema tests: applied in YAML, returns the number of records that do not pass an assertion —
 					// when this number is 0, all records pass, therefore, your test passes
 					var results [][]bigquery.Value
-					results, _, err = bigquery.GetRows(query, target)
+					results, _, err = bigquery.GetRows(ctx, query, target)
 
 					if err == nil {
 						if len(results) != 1 {

--- a/compiler/dbtUtils/queryMacros.go
+++ b/compiler/dbtUtils/queryMacros.go
@@ -1,6 +1,7 @@
 package dbtUtils
 
 import (
+	"context"
 	"ddbt/bigquery"
 	"ddbt/compilerInterface"
 	"fmt"
@@ -8,7 +9,13 @@ import (
 	"strings"
 )
 
+// GetColumnValues is a fallback GetColumnValuesWithContext
+// with a background context.
 func GetColumnValues(ec compilerInterface.ExecutionContext, caller compilerInterface.AST, arguments compilerInterface.Arguments) (*compilerInterface.Value, error) {
+	return GetColumnValuesWithContext(context.Background(), ec, caller, arguments)
+}
+
+func GetColumnValuesWithContext(ctx context.Context, ec compilerInterface.ExecutionContext, caller compilerInterface.AST, arguments compilerInterface.Arguments) (*compilerInterface.Value, error) {
 	if isOnlyCompilingSQL(ec) {
 		return ec.MarkAsDynamicSQL()
 	}
@@ -39,7 +46,7 @@ func GetColumnValues(ec compilerInterface.ExecutionContext, caller compilerInter
 		return nil, ec.ErrorAt(caller, fmt.Sprintf("%s", err))
 	}
 
-	rows, _, err := bigquery.GetRows(query, target)
+	rows, _, err := bigquery.GetRows(ctx, query, target)
 	if err != nil {
 		return nil, ec.ErrorAt(caller, fmt.Sprintf("get_column_values query returned an error: %s", err))
 	}

--- a/utils/version.go
+++ b/utils/version.go
@@ -1,3 +1,3 @@
 package utils
 
-const DdbtVersion = "0.4.5"
+const DdbtVersion = "0.4.6"


### PR DESCRIPTION
This PR adds the `-m` flag to `schema-gen`.
```
ddbt schema-gen --help
Generates the YML schema file for a given model

Usage:
  ddbt schema-gen [model name] [flags]

Flags:
  -h, --help           help for schema-gen
  -m, --models stringArray   Select which model(s) to run
```

It didn't make much sense to break the `ddbt schema-gen model-name` workflow so quickly, so it's supporting both
```
ddbt schema-gen model-name
```
and
```
ddbt schema-gen -m model-name
```
For now, but I'm open to completely migrating to the `-m` version.