### PR TITLE
Continue and warn on missing models instead of fail

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -234,9 +234,8 @@ func buildGraph(fileSystem *fs.FileSystem, modelFilters []string) *fs.Graph {
 
 				model := fileSystem.Model(modelFilter)
 				if model == nil {
-					pb.Stop()
-					fmt.Printf("❌ Unable to find model: %s\n", strings.Join(modelFilters, ", "))
-					os.Exit(1)
+					fmt.Printf("❓ Unable to find model: %s\n", modelFilter)
+					continue
 				}
 
 				graph.AddNode(model)


### PR DESCRIPTION
dbt does not error if a bad model selector is provided (nor does it warn).
These changes will model selectors that do not correspond to models that exist but it will also warn the user: best of both worlds.
We rely on this behaviour in the analytics CI process.