### PR TITLE
Print model not found warnings to stderr

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -245,7 +245,7 @@ func buildGraph(fileSystem *fs.FileSystem, modelFilters []string) *fs.Graph {
 						pb.Stop()
 						os.Exit(1)
 					} else {
-						println("\n  ❓ Unable to find model:", modelFilter)
+						fmt.Fprintf(os.Stderr, "\n  ❓ Unable to find model: %s\n", modelFilter)
 						continue
 					}
 				}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -241,11 +241,11 @@ func buildGraph(fileSystem *fs.FileSystem, modelFilters []string) *fs.Graph {
 				model := fileSystem.Model(modelFilter)
 				if model == nil {
 					if FailOnNotFound {
-						pb.Stop()
 						fmt.Printf("❌ Unable to find model: %s\n", modelFilter)
+						pb.Stop()
 						os.Exit(1)
 					} else {
-						fmt.Printf("❓ Unable to find model: %s\n", modelFilter)
+						println("\n  ❓ Unable to find model:", modelFilter)
 						continue
 					}
 				}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -241,8 +241,8 @@ func buildGraph(fileSystem *fs.FileSystem, modelFilters []string) *fs.Graph {
 				model := fileSystem.Model(modelFilter)
 				if model == nil {
 					if FailOnNotFound {
-						fmt.Printf("❌ Unable to find model: %s\n", modelFilter)
 						pb.Stop()
+						fmt.Printf("❌ Unable to find model: %s\n", modelFilter)
 						os.Exit(1)
 					} else {
 						fmt.Fprintf(os.Stderr, "\n  ❓ Unable to find model: %s\n", modelFilter)


### PR DESCRIPTION
If we're trying to capture the output of `isolate-dag` (the new isolated directory) it will include any warning messages, print warnings to stderr instead so it doesn't.