### PR TITLE
isolate-dag: include upstream ephemeral nodes in isolated dag

### DIFF
--- a/fs/graph.go
+++ b/fs/graph.go
@@ -270,7 +270,7 @@ func (g *Graph) AddReferencingTests() []*File {
 }
 
 // addEphemeralUpstreamsFor recursively adds upstream ephemeral nodes to a given node
-func (g *Graph) addEphemeralUpstreamsFor(node *Node) error {
+func (g *Graph) addEphemeralUpstreamsFor(node *Node) {
 	for upstream := range node.file.upstreams {
 		if upstream.Type != ModelFile {
 			continue
@@ -282,25 +282,18 @@ func (g *Graph) addEphemeralUpstreamsFor(node *Node) error {
 
 		upstreamNode := g.getNodeFor(upstream)
 		g.edge(upstreamNode, node)
-
-		if err := g.addEphemeralUpstreamsFor(upstreamNode); err != nil {
-			return err
-		}
+		g.addEphemeralUpstreamsFor(upstreamNode)
 	}
-	return nil
 }
 
 // AddEphemeralUpstreams brings any upstream models that are ephemeral into the graph
-func (g *Graph) AddEphemeralUpstreams() error {
+func (g *Graph) AddEphemeralUpstreams() {
 	for _, node := range g.nodes {
 		if node.file.Type != ModelFile {
 			continue
 		}
-		if err := g.addEphemeralUpstreamsFor(node); err != nil {
-			return err
-		}
+		g.addEphemeralUpstreamsFor(node)
 	}
-	return nil
 }
 
 func (g *Graph) Len() int {

--- a/fs/graph.go
+++ b/fs/graph.go
@@ -269,6 +269,28 @@ func (g *Graph) AddReferencingTests() []*File {
 	return tests
 }
 
+// AddEphemeralUpstreams brings any upstream models that are ephemeral into the graph
+func (g *Graph) AddEphemeralUpstreams() {
+	for _, node := range g.nodes {
+		if node.file.Type != ModelFile {
+			continue
+		}
+
+		for upstream := range node.file.upstreams {
+			if upstream.Type != ModelFile {
+				continue
+			}
+
+			if upstream.GetMaterialization() != "ephemeral" {
+				continue
+			}
+
+			upstreamNode := g.getNodeFor(upstream)
+			g.edge(node, upstreamNode)
+		}
+	}
+}
+
 func (g *Graph) Len() int {
 	return len(g.nodes)
 }


### PR DESCRIPTION
Avoids failure when:

`myslurpee` > `mymodel`

```
cd $(ddbt isolate-dag -m mymodel)
dbt run -m mymodel
```

With the current implementation, a blank CTE will be injected and the query will fail.