### PR TITLE
Allow view keyword as Materialization option

### DIFF
--- a/compiler/ExecutionContext.go
+++ b/compiler/ExecutionContext.go
@@ -119,7 +119,7 @@ func (e *ExecutionContext) RegisterUpstreamAndGetRef(modelName string, fileType 
 	}
 
 	switch upstream.GetMaterialization() {
-	case "table", "incremental", "project_sharded_table":
+	case "table", "incremental", "project_sharded_table", "view":
 		// If "--upstream=target" has been provided and this model is not in the DAG, then we read from the upstream
 		// target, rather than the target defined in "--target=target"
 		if target.ReadUpstream != nil && !upstream.IsInDAG() {

--- a/compiler/ExecutionContext.go
+++ b/compiler/ExecutionContext.go
@@ -120,6 +120,8 @@ func (e *ExecutionContext) RegisterUpstreamAndGetRef(modelName string, fileType 
 
 	switch upstream.GetMaterialization() {
 	case "table", "incremental", "project_sharded_table", "view":
+		//ToDo: views are being treated as tables until they are properly implemented
+		
 		// If "--upstream=target" has been provided and this model is not in the DAG, then we read from the upstream
 		// target, rather than the target defined in "--target=target"
 		if target.ReadUpstream != nil && !upstream.IsInDAG() {


### PR DESCRIPTION
This is quite a tricky one because of the dependencies between dbt-ddbt in our CI checks in github.

DBT allows us to create views instead of tables, this can be done through the following configuration:
```
{{
    config(
        tags=[
         ....
        ],
        materialized='view'
    )
}}
```

This will perform a `CREATE OR REPLACE VIEW` instead of a `CREATE OR REPLACE TABLE`.

Unfortunately, DDBT doesn't have this functionality, so when trying to set this configuration, we will hit the following error:
`❌ Unable to compile model XXX: unknown materialized config 'view' in model 'XXX'`

The main problem is that, because of how we are using now ddbt to do the CI checks, even though we are allowing views in our dbt version in prod, the ddbt command is going to block the CI checks with the same error:
`❌ Unable to compile model XXX: unknown materialized config 'view' in model 'XXX'`

Could we, even though DDBT is still not supporting views, allow this parameter in the Materialization option? this follows the same idea behind allowing `incremental`/`project_sharded_table`