### PR TITLE
adding new override

### DIFF
--- a/config/modelGroups.go
+++ b/config/modelGroups.go
@@ -93,13 +93,11 @@ func updateTargetFromModelGroupConfig(target *Target, targetName string, targetC
 					return err
 				}
 				overrideUserDataset := os.Getenv("OVERRIDE_USER_DATASET")
-				var username string
 				if overrideUserDataset != "" {
-					username = overrideUserDataset
+					target.DataSet = fmt.Sprintf(overrideUserDataset)
 				} else {
-					username = u.Username
+					target.DataSet = fmt.Sprintf("dbt_%s_%s", u.Username, targetName)
 				}
-				target.DataSet = fmt.Sprintf("dbt_%s_%s", username, targetName)
 			} else {
 				return errors.New("expected dataset to be string or { 'from_env': true }")
 			}

--- a/config/modelGroups.go
+++ b/config/modelGroups.go
@@ -92,9 +92,9 @@ func updateTargetFromModelGroupConfig(target *Target, targetName string, targetC
 				if err != nil {
 					return err
 				}
-				overrideUserDataset := os.Getenv("OVERRIDE_DATASET_NAME")
-				if overrideUserDataset != "" {
-					target.DataSet = overrideUserDataset
+				dbtUsername := os.Getenv("DBT_USER")
+				if dbtUsername != "" {
+					target.DataSet = fmt.Sprintf("dbt_%s_%s", dbtUsername, targetName)
 				} else {
 					target.DataSet = fmt.Sprintf("dbt_%s_%s", u.Username, targetName)
 				}

--- a/config/modelGroups.go
+++ b/config/modelGroups.go
@@ -92,7 +92,7 @@ func updateTargetFromModelGroupConfig(target *Target, targetName string, targetC
 				if err != nil {
 					return err
 				}
-				overrideUserDataset := os.Getenv("OVERRIDE_USER_DATASET")
+				overrideUserDataset := os.Getenv("OVERRIDE_DATASET_NAME")
 				if overrideUserDataset != "" {
 					target.DataSet = fmt.Sprintf(overrideUserDataset)
 				} else {

--- a/config/modelGroups.go
+++ b/config/modelGroups.go
@@ -94,7 +94,7 @@ func updateTargetFromModelGroupConfig(target *Target, targetName string, targetC
 				}
 				overrideUserDataset := os.Getenv("OVERRIDE_DATASET_NAME")
 				if overrideUserDataset != "" {
-					target.DataSet = fmt.Sprintf(overrideUserDataset)
+					target.DataSet = overrideUserDataset
 				} else {
 					target.DataSet = fmt.Sprintf("dbt_%s_%s", u.Username, targetName)
 				}

--- a/config/modelGroups.go
+++ b/config/modelGroups.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"os/user"
 
 	"gopkg.in/yaml.v2"
@@ -91,8 +92,14 @@ func updateTargetFromModelGroupConfig(target *Target, targetName string, targetC
 				if err != nil {
 					return err
 				}
-
-				target.DataSet = fmt.Sprintf("dbt_%s_%s", u.Username, targetName)
+				overrideUserDataset := os.Getenv("OVERRIDE_USER_DATASET")
+				var username string
+				if overrideUserDataset != "" {
+					username = overrideUserDataset
+				} else {
+					username = u.Username
+				}
+				target.DataSet = fmt.Sprintf("dbt_%s_%s", username, targetName)
 			} else {
 				return errors.New("expected dataset to be string or { 'from_env': true }")
 			}


### PR DESCRIPTION
Currently people use `ddbt` in the `dbt-monzo` docker image.

This breaks when interacting with the dataset and users get `dbt_dbtuser_dev` dataset errors. 

We need some mechanism to override this in the docker image. Am very open to suggestions on how is best to override.