### PR TITLE
Upgrade language version

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ go install
 4. Confirm installation
 ```bash
 $ ddbt --version
-ddbt version 0.6.2
+ddbt version 0.6.3
 ```
 
 ## Command Quickstart

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ go install
 4. Confirm installation
 ```bash
 $ ddbt --version
-ddbt version 0.2.1
+ddbt version 0.6.2
 ```
 
 ## Command Quickstart

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module ddbt
 
-go 1.14
+go 1.16
 
 require (
 	cloud.google.com/go/bigquery v1.10.0

--- a/utils/version.go
+++ b/utils/version.go
@@ -1,3 +1,3 @@
 package utils
 
-const DdbtVersion = "0.6.2"
+const DdbtVersion = "0.6.3"


### PR DESCRIPTION
I just tried to brew install ddbt on an M1, but the go language version is incompatible. 

This PR bumps the language version. I've done a test run of ddbt and seems to work as before.

I've not used git tags before - but I've run:
```bash
$ git tag v0.6.3
$ git push origin v0.6.3
Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
To github.com:monzo/ddbt.git
 * [new tag]         v0.6.3 -> v0.6.3
```
Not sure if there is anything else to do here.

Once merged, I'll raise a PR on the tap: https://github.com/monzo/tap/blob/e955898fffe25aeeedb1d793b7ac254b97e10fd9/Formula/ddbt.rb