### PR TITLE
ddbt isolate-dag: warn on empty DAG instead of exit

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -299,8 +299,7 @@ func buildGraph(fileSystem *fs.FileSystem, modelFilters []string) *fs.Graph {
 	pb.Increment()
 
 	if graph.Len() == 0 {
-		fmt.Printf("❌ Empty DAG generated for model filter: %s\n", strings.Join(modelFilters, ", "))
-		os.Exit(1)
+		fmt.Printf("⚠️ Empty DAG generated for model filter: %s\n", strings.Join(modelFilters, ", "))
 	}
 
 	return graph

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -299,7 +299,13 @@ func buildGraph(fileSystem *fs.FileSystem, modelFilters []string) *fs.Graph {
 	pb.Increment()
 
 	if graph.Len() == 0 {
-		fmt.Printf("⚠️ Empty DAG generated for model filter: %s\n", strings.Join(modelFilters, ", "))
+		switch FailOnNotFound {
+		case true:
+			fmt.Printf("❌ Empty DAG generated for model filter: %s\n", strings.Join(modelFilters, ", "))
+			os.Exit(1)
+		case false:
+			fmt.Printf("⚠️ Empty DAG generated for model filter: %s\n", strings.Join(modelFilters, ", "))
+		}
 	}
 
 	return graph


### PR DESCRIPTION
It can still be useful to run dbt commands in an isolated environment even if the selected DAG is empty, so warn instead of exiting.