### PR TITLE
Fix `execute` variable in macros & enable get columns in adapter

### DIFF
--- a/compiler/GlobalContext.go
+++ b/compiler/GlobalContext.go
@@ -173,7 +173,11 @@ func (g *GlobalContext) GetMacro(name string) (compilerInterface.FunctionDef, er
 		newEC := ec.PushState()
 		// Note we copy any varaibles defined within the macro's own file in to the context being executed here too
 		macro.ec.CopyVariablesInto(newEC)
+
+		// We keep the caller and execute context however as these will change from when the macro was registered to when
+		// it is called
 		newEC.SetVariable("caller", ec.GetVariable("caller"))
+		newEC.SetVariable("execute", ec.GetVariable("execute"))
 
 		return macro.function(newEC, caller, args)
 	}, nil

--- a/compiler/dbtUtils/queryMacros.go
+++ b/compiler/dbtUtils/queryMacros.go
@@ -2,11 +2,12 @@ package dbtUtils
 
 import (
 	"context"
-	"ddbt/bigquery"
-	"ddbt/compilerInterface"
 	"fmt"
 	"strconv"
 	"strings"
+
+	"ddbt/bigquery"
+	"ddbt/compilerInterface"
 )
 
 // GetColumnValues is a fallback GetColumnValuesWithContext
@@ -16,11 +17,11 @@ func GetColumnValues(ec compilerInterface.ExecutionContext, caller compilerInter
 }
 
 func GetColumnValuesWithContext(ctx context.Context, ec compilerInterface.ExecutionContext, caller compilerInterface.AST, arguments compilerInterface.Arguments) (*compilerInterface.Value, error) {
-	if isOnlyCompilingSQL(ec) {
+	if IsOnlyCompilingSQL(ec) {
 		return ec.MarkAsDynamicSQL()
 	}
 
-	args, err := getArgs(arguments, param("table"), param("column"), param("max_records"))
+	args, err := GetArgs(arguments, Param("table"), Param("column"), Param("max_records"))
 	if err != nil {
 		return nil, ec.ErrorAt(caller, fmt.Sprintf("%s", err))
 	}
@@ -66,17 +67,17 @@ func GetColumnValuesWithContext(ctx context.Context, ec compilerInterface.Execut
 }
 
 func Unpivot(ec compilerInterface.ExecutionContext, caller compilerInterface.AST, arguments compilerInterface.Arguments) (*compilerInterface.Value, error) {
-	if isOnlyCompilingSQL(ec) {
+	if IsOnlyCompilingSQL(ec) {
 		return ec.MarkAsDynamicSQL()
 	}
 
-	args, err := getArgs(arguments,
-		paramWithDefault("table", compilerInterface.NewString("")),
-		paramWithDefault("cast_to", compilerInterface.NewString("varchar")),
-		paramWithDefault("exclude", compilerInterface.NewList(make([]*compilerInterface.Value, 0))),
-		paramWithDefault("remove", compilerInterface.NewList(make([]*compilerInterface.Value, 0))),
-		paramWithDefault("field_name", compilerInterface.NewString("field_name")),
-		paramWithDefault("value_name", compilerInterface.NewString("value_name")),
+	args, err := GetArgs(arguments,
+		ParamWithDefault("table", compilerInterface.NewString("")),
+		ParamWithDefault("cast_to", compilerInterface.NewString("varchar")),
+		ParamWithDefault("exclude", compilerInterface.NewList(make([]*compilerInterface.Value, 0))),
+		ParamWithDefault("remove", compilerInterface.NewList(make([]*compilerInterface.Value, 0))),
+		ParamWithDefault("field_name", compilerInterface.NewString("field_name")),
+		ParamWithDefault("value_name", compilerInterface.NewString("value_name")),
 	)
 	if err != nil {
 		return nil, ec.ErrorAt(caller, fmt.Sprintf("%s", err))

--- a/compiler/dbtUtils/replacements.go
+++ b/compiler/dbtUtils/replacements.go
@@ -10,7 +10,7 @@ import (
 )
 
 func UnionAllTables(ec compilerInterface.ExecutionContext, caller compilerInterface.AST, arguments compilerInterface.Arguments) (*compilerInterface.Value, error) {
-	args, err := getArgs(arguments, param("tables"), param("column_names"))
+	args, err := GetArgs(arguments, Param("tables"), Param("column_names"))
 	if err != nil {
 		return nil, ec.ErrorAt(caller, fmt.Sprintf("%s", err))
 	}
@@ -45,7 +45,7 @@ func UnionAllTables(ec compilerInterface.ExecutionContext, caller compilerInterf
 }
 
 func GroupBy(ec compilerInterface.ExecutionContext, caller compilerInterface.AST, arguments compilerInterface.Arguments) (*compilerInterface.Value, error) {
-	args, err := getArgs(arguments, paramWithDefault("n", compilerInterface.NewNumber(0)))
+	args, err := GetArgs(arguments, ParamWithDefault("n", compilerInterface.NewNumber(0)))
 	if err != nil {
 		return nil, ec.ErrorAt(caller, fmt.Sprintf("%s", err))
 	}
@@ -68,17 +68,17 @@ func GroupBy(ec compilerInterface.ExecutionContext, caller compilerInterface.AST
 }
 
 func Pivot(ec compilerInterface.ExecutionContext, caller compilerInterface.AST, arguments compilerInterface.Arguments) (*compilerInterface.Value, error) {
-	args, err := getArgs(arguments,
-		paramWithDefault("column", compilerInterface.NewString("")),
-		paramWithDefault("values", compilerInterface.NewList(make([]*compilerInterface.Value, 0))),
-		paramWithDefault("alias", compilerInterface.NewBoolean(true)),
-		paramWithDefault("agg", compilerInterface.NewString("sum")),
-		paramWithDefault("cmp", compilerInterface.NewString("=")),
-		paramWithDefault("prefix", compilerInterface.NewString("")),
-		paramWithDefault("suffix", compilerInterface.NewString("")),
-		param("then_value"),
-		param("else_value"),
-		paramWithDefault("quote_identifiers", compilerInterface.NewBoolean(true)),
+	args, err := GetArgs(arguments,
+		ParamWithDefault("column", compilerInterface.NewString("")),
+		ParamWithDefault("values", compilerInterface.NewList(make([]*compilerInterface.Value, 0))),
+		ParamWithDefault("alias", compilerInterface.NewBoolean(true)),
+		ParamWithDefault("agg", compilerInterface.NewString("sum")),
+		ParamWithDefault("cmp", compilerInterface.NewString("=")),
+		ParamWithDefault("prefix", compilerInterface.NewString("")),
+		ParamWithDefault("suffix", compilerInterface.NewString("")),
+		Param("then_value"),
+		Param("else_value"),
+		ParamWithDefault("quote_identifiers", compilerInterface.NewBoolean(true)),
 	)
 	if err != nil {
 		return nil, ec.ErrorAt(caller, fmt.Sprintf("%s", err))

--- a/compiler/dbtUtils/utils.go
+++ b/compiler/dbtUtils/utils.go
@@ -1,22 +1,23 @@
 package dbtUtils
 
 import (
-	"ddbt/compilerInterface"
 	"fmt"
+
+	"ddbt/compilerInterface"
 )
 
-func param(name string) compilerInterface.Argument {
-	return paramWithDefault(name, nil)
+func Param(name string) compilerInterface.Argument {
+	return ParamWithDefault(name, nil)
 }
 
-func paramWithDefault(name string, value *compilerInterface.Value) compilerInterface.Argument {
+func ParamWithDefault(name string, value *compilerInterface.Value) compilerInterface.Argument {
 	return compilerInterface.Argument{
 		Name:  name,
 		Value: value,
 	}
 }
 
-func getArgs(arguments compilerInterface.Arguments, params ...compilerInterface.Argument) ([]*compilerInterface.Value, error) {
+func GetArgs(arguments compilerInterface.Arguments, params ...compilerInterface.Argument) ([]*compilerInterface.Value, error) {
 	args := make([]*compilerInterface.Value, len(params))
 
 	// quick lookup map
@@ -62,7 +63,7 @@ func getArgs(arguments compilerInterface.Arguments, params ...compilerInterface.
 	return args, nil
 }
 
-func isOnlyCompilingSQL(ec compilerInterface.ExecutionContext) bool {
+func IsOnlyCompilingSQL(ec compilerInterface.ExecutionContext) bool {
 	value := ec.GetVariable("execute")
 
 	if value.Type() == compilerInterface.BooleanValue {

--- a/jinja/ast/Variable.go
+++ b/jinja/ast/Variable.go
@@ -136,7 +136,7 @@ func (v *Variable) resolvePropertyLookup(ec compilerInterface.ExecutionContext, 
 		return nil, err
 	}
 
-	data := value.Properties()
+	data := value.Properties(isForFunctionCall)
 	if data == nil {
 		return nil, ec.ErrorAt(v, fmt.Sprintf("unable reference by property key in a %s", value.Type()))
 	}

--- a/utils/version.go
+++ b/utils/version.go
@@ -1,3 +1,3 @@
 package utils
 
-const DdbtVersion = "0.6.3"
+const DdbtVersion = "0.6.4"


### PR DESCRIPTION
Previously the variable `execute` when read inside macro's would always be false - as when the macro was compiled it was false, and the macro's compilation context was still present. This change passes in what ever the current `execute` variable value is.

This commit also adds the ability to get the columns in a model