### PR TITLE
Enable alternative config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ ddbt version 0.6.5
 - `--upstream=y` _or_ `-u y`: For any references to models outside the explicit models specified by run or test, the upstream target used to read that data will be swapped to `y` instead of the output target of `x`
 - `--fail-on-not-found=false` _or_ `-f=false`: By default, ddbt will fail if a the specified models don't exist, passing in this argument as false will warn instead of failing
 - `--enable-schema-based-tests` _or_ `-s=true`: Schema-based tests are disabled by default for now, but as a way to enable them pass this argument as true
-- `--custom-config-path=myCustomPathWithTrailingSlash/` _or_ `-c=myCustomPathWithTrailingSlash/`: Allows a custom path to be used for the `dbt_project.yml`. This is useful if you want to use a different location than the default one. For example if you're mid-way through migrating commands from an old dbt version to a new version and using two different versions of `dbt_project.yml` at the same time.
+- `--custom-config-path=my/custom/path` _or_ `-c=my/custom/path`: Allows a custom path to be used for the `dbt_project.yml`. This is useful if you want to use a different location than the default one. For example if you're mid-way through migrating commands from an old dbt version to a new version and using two different versions of `dbt_project.yml` at the same time.
 
 ### Model Filters
 When running or testing the project, you may only want to run for a subset of your models.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://github.com/monzo/ddbt/actions/workflows/tests.yml/badge.svg)](https://github.com/monzo/ddbt/actions/workflows/tests.yml)
 [![GoDoc](https://godoc.org/github.com/monzo/ddbt?status.svg)](https://godoc.org/github.com/monzo/ddbt)
 
-This repo represents my attempt to build a fast version of [DBT](https://www.getdbt.com/) which gets very slow on large 
+This repo represents my attempt to build a fast version of [DBT](https://www.getdbt.com/) which gets very slow on large
 projects (3000+ data models). This project attempts to be a direct drop in replacement for DBT at the command line.
 
 *Warning:* This is experimental and may not work exactly as you expect
@@ -27,7 +27,7 @@ $ go install
 4. Confirm installation
 ```bash
 $ ddbt --version
-ddbt version 0.6.3
+ddbt version 0.6.5
 ```
 
 ## Command Quickstart
@@ -47,9 +47,10 @@ ddbt version 0.6.3
 - `--models model_filter` _or_ `-m model_filter`: Instead of running for every model in your project, DDBT will only execute against the requested models. See filters below for what is accepted for `my_model`
 - `--threads=n`: force DDBT to run with `n`  threads instead of what is defined in your `dbt_project.yml`
 - `--target=x` _or_ `-t x`: force DDBT to run against the `x` output defined in your `profile.yml` instead of the default defined in that file.
-- `--upstream=y` _or_ `-u y`: For any references to models outside the explicit models specified by run or test, the upstream target used to read that data will be swapped to `y` instead of the output target of `x`  
-- `--fail-on-not-found=false` _or_ `-f=false`: By default, ddbt will fail if a the specified models don't exist, passing in this argument as false will warn instead of failing  
-- `--enable-schema-based-tests` _or_ `-s=true`: Schema-based tests are disabled by default for now, but as a way to enable them pass this argument as true 
+- `--upstream=y` _or_ `-u y`: For any references to models outside the explicit models specified by run or test, the upstream target used to read that data will be swapped to `y` instead of the output target of `x`
+- `--fail-on-not-found=false` _or_ `-f=false`: By default, ddbt will fail if a the specified models don't exist, passing in this argument as false will warn instead of failing
+- `--enable-schema-based-tests` _or_ `-s=true`: Schema-based tests are disabled by default for now, but as a way to enable them pass this argument as true
+- `--custom-config-path=myCustomPathWithTrailingSlash/` _or_ `-c myCustomPathWithTrailingSlash/`: Allows a custom path to be used for the dbt config and project files. This is useful if you want to use a different location than the default one. For example if you're mid-way through migrating commands from an old dbt version to a new version and using two different versions of config at the same time.
 
 ### Model Filters
 When running or testing the project, you may only want to run for a subset of your models.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ ddbt version 0.6.5
 - `--upstream=y` _or_ `-u y`: For any references to models outside the explicit models specified by run or test, the upstream target used to read that data will be swapped to `y` instead of the output target of `x`
 - `--fail-on-not-found=false` _or_ `-f=false`: By default, ddbt will fail if a the specified models don't exist, passing in this argument as false will warn instead of failing
 - `--enable-schema-based-tests` _or_ `-s=true`: Schema-based tests are disabled by default for now, but as a way to enable them pass this argument as true
-- `--custom-config-path=myCustomPathWithTrailingSlash/` _or_ `-c=myCustomPathWithTrailingSlash/`: Allows a custom path to be used for the dbt config and project files. This is useful if you want to use a different location than the default one. For example if you're mid-way through migrating commands from an old dbt version to a new version and using two different versions of config at the same time.
+- `--custom-config-path=myCustomPathWithTrailingSlash/` _or_ `-c=myCustomPathWithTrailingSlash/`: Allows a custom path to be used for the `dbt_project.yml`. This is useful if you want to use a different location than the default one. For example if you're mid-way through migrating commands from an old dbt version to a new version and using two different versions of `dbt_project.yml` at the same time.
 
 ### Model Filters
 When running or testing the project, you may only want to run for a subset of your models.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ ddbt version 0.6.5
 - `--upstream=y` _or_ `-u y`: For any references to models outside the explicit models specified by run or test, the upstream target used to read that data will be swapped to `y` instead of the output target of `x`
 - `--fail-on-not-found=false` _or_ `-f=false`: By default, ddbt will fail if a the specified models don't exist, passing in this argument as false will warn instead of failing
 - `--enable-schema-based-tests` _or_ `-s=true`: Schema-based tests are disabled by default for now, but as a way to enable them pass this argument as true
-- `--custom-config-path=myCustomPathWithTrailingSlash/` _or_ `-c myCustomPathWithTrailingSlash/`: Allows a custom path to be used for the dbt config and project files. This is useful if you want to use a different location than the default one. For example if you're mid-way through migrating commands from an old dbt version to a new version and using two different versions of config at the same time.
+- `--custom-config-path=myCustomPathWithTrailingSlash/` _or_ `-c=myCustomPathWithTrailingSlash/`: Allows a custom path to be used for the dbt config and project files. This is useful if you want to use a different location than the default one. For example if you're mid-way through migrating commands from an old dbt version to a new version and using two different versions of config at the same time.
 
 ### Model Filters
 When running or testing the project, you may only want to run for a subset of your models.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,12 +31,14 @@ var (
 	targetProfile   string
 	upstreamProfile string
 	threads         int
+	customConfigPath string
 )
 
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&targetProfile, "target", "t", "", "Which target profile to use")
 	rootCmd.PersistentFlags().StringVarP(&upstreamProfile, "upstream", "u", "", "Which target profile to use when reading data outside the current DAG")
 	rootCmd.PersistentFlags().IntVar(&threads, "threads", 0, "How many threads to execute with")
+	rootCmd.PersistentFlags().StringVarP(&customConfigPath, "custom-config-path", "c", "", "Pass in a custom config path")
 }
 
 func Execute() {
@@ -51,7 +53,7 @@ func initDDBT() {
 	cdIntoDBTFolder()
 
 	// Read the project config
-	cfg, err := config.Read(targetProfile, upstreamProfile, threads, compiler.CompileStringWithCache)
+	cfg, err := config.Read(targetProfile, upstreamProfile, threads, customConfigPath, compiler.CompileStringWithCache)
 	if err != nil {
 		fmt.Printf("❌ Unable to load config: %s\n", err)
 		os.Exit(1)

--- a/config/config.go
+++ b/config/config.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
-	// "ddbt/cmd"
 
 	"gopkg.in/yaml.v2"
 )
@@ -155,8 +154,22 @@ type dbtProject struct {
 	Seeds   map[string]map[string]interface{} `yaml:"seeds"`  // "Seeds[project_name][key]value"
 }
 
+func handleCustomConfigPath(customConfigPath string) (string, error) {
+	// if a custom path is provided, ensure that a trailing slash is present
+	if customConfigPath != "" {
+		customConfigPath = strings.TrimRight(customConfigPath, string(os.PathSeparator))
+		customConfigPath = customConfigPath + string(os.PathSeparator)
+	}
+	return customConfigPath, nil
+}
+
 func readDBTProject(customConfigPath string) (dbtProject, error) {
 	project := dbtProject{}
+
+	customConfigPath, err := handleCustomConfigPath(customConfigPath)
+	if err != nil {
+		return dbtProject{}, err
+	}
 
 	bytes, err := ioutil.ReadFile(customConfigPath + "dbt_project.yml")
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	// "ddbt/cmd"
 
 	"gopkg.in/yaml.v2"
 )
@@ -45,8 +46,8 @@ func (c *Config) GetTargetFor(path string) *Target {
 
 var GlobalCfg *Config
 
-func Read(targetProfile string, upstreamProfile string, threads int, strExecutor func(s string) (string, error)) (*Config, error) {
-	project, err := readDBTProject()
+func Read(targetProfile string, upstreamProfile string, threads int, customConfigPath string, strExecutor func(s string) (string, error)) (*Config, error) {
+	project, err := readDBTProject(customConfigPath)
 	if err != nil {
 		return nil, err
 	}
@@ -154,10 +155,10 @@ type dbtProject struct {
 	Seeds   map[string]map[string]interface{} `yaml:"seeds"`  // "Seeds[project_name][key]value"
 }
 
-func readDBTProject() (dbtProject, error) {
+func readDBTProject(customConfigPath string) (dbtProject, error) {
 	project := dbtProject{}
 
-	bytes, err := ioutil.ReadFile("dbt_project.yml")
+	bytes, err := ioutil.ReadFile(customConfigPath + "dbt_project.yml")
 	if err != nil {
 		return dbtProject{}, err
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,46 @@
+package config
+
+import "testing"
+
+func Test_handleCustomConfigPath(t *testing.T) {
+	type args struct {
+		customConfigPath string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		// path with trailing slash returns same path
+		{
+			name: "path with trailing slash",
+			args: args{
+				customConfigPath: "foo/",
+			},
+			want:    "foo/",
+			wantErr: false,
+		},
+		// path without trailing slash returns path with trailing slash
+		{
+			name: "path without trailing slash",
+			args: args{
+				customConfigPath: "foo",
+			},
+			want:    "foo/",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := handleCustomConfigPath(tt.args.customConfigPath)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("handleCustomConfigPath() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("handleCustomConfigPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/utils/version.go
+++ b/utils/version.go
@@ -1,3 +1,3 @@
 package utils
 
-const DdbtVersion = "0.6.4"
+const DdbtVersion = "0.6.5"


### PR DESCRIPTION
This PR allows a custom path to be used for the dbt config and project files. This is useful if you want to use a different location than the default one. For example if you're mid-way through migrating commands from an old dbt version to a new version and using two different versions of config at the same time.