### PR TITLE
Apply a hack for dbt migration

### DIFF
--- a/cmd/isolateDAG.go
+++ b/cmd/isolateDAG.go
@@ -147,6 +147,8 @@ func isolateGraph(graph *fs.Graph) {
 		"docs",
 		"dbt_modules",
 		"macros",
+		// Hack for migration where we're using two version of dbt
+		"dbt_modules_v0_21_x",
 	}
 
 	// If we have a model groups file bring that too

--- a/utils/version.go
+++ b/utils/version.go
@@ -1,3 +1,3 @@
 package utils
 
-const DdbtVersion = "0.6.5"
+const DdbtVersion = "0.6.6"


### PR DESCRIPTION
In our current situation at Monzo, we are migrating between an old version of dbt to a new version. Both version are being used at the same time, akin to [the strangler fig pattern](https://docs.microsoft.com/en-us/azure/architecture/patterns/strangler-fig). This PR applies a small fix so the isolate functionality copies over the dbt modules the new version of dbt expects.