### PR TITLE
DP-639 isolate-dag command does not fail for usage of is_marked_for_full_refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ go install
 4. Confirm installation
 ```bash
 $ ddbt --version
-ddbt version 0.6.5
+ddbt version 0.6.7
 ```
 
 ## Command Quickstart

--- a/compiler/builtInFunctions.go
+++ b/compiler/builtInFunctions.go
@@ -198,6 +198,9 @@ var builtInFunctions = map[string]compilerInterface.FunctionDef{
 	// Our specific functions
 	"indirect_ref": refFunction,
 
+	// Our specific functions ( without implementations in ddbt )
+	"is_marked_for_full_refresh": noopMethod(),
+
 	// DDBT Debugging function - Allows removing of macro's from models without completely removing them
 	"noop": func(ec compilerInterface.ExecutionContext, caller compilerInterface.AST, args compilerInterface.Arguments) (*compilerInterface.Value, error) {
 		return compilerInterface.NewUndefined(), nil

--- a/utils/version.go
+++ b/utils/version.go
@@ -1,3 +1,3 @@
 package utils
 
-const DdbtVersion = "0.6.6"
+const DdbtVersion = "0.6.7"


### PR DESCRIPTION
Makes ddbt aware of the is_marked_for_full_refresh() macro, so it is not erroring during isolate-dag

Before:
![Screenshot 2022-04-13 at 11 53 29](https://user-images.githubusercontent.com/11160754/163165703-6cd87c38-f583-4047-9ff2-3e4c99fa33d9.png)

After:
![Screenshot 2022-04-13 at 11 55 37](https://user-images.githubusercontent.com/11160754/163165722-9c3ad9b6-40ce-49d6-a4d6-191c53af0a3a.png)
