### PR TITLE
Isolate should not change the isolation directory format

### DIFF
--- a/cmd/isolateDAG.go
+++ b/cmd/isolateDAG.go
@@ -225,5 +225,7 @@ func isolateGraph(graph *fs.Graph) {
 
 	pb.Stop()
 
-	fmt.Printf("Isolation Directory: %s\n", isolationDir)
+	// NB: Some scripts are relying on this being the last line of output
+	//     Please be careful when changing the semantics of this
+	fmt.Print(isolationDir)
 }

--- a/utils/version.go
+++ b/utils/version.go
@@ -1,3 +1,3 @@
 package utils
 
-const DdbtVersion = "0.6.8"
+const DdbtVersion = "0.6.9"


### PR DESCRIPTION
I've found some scripts we use internally that expect this output to only contain the directory. We shouldn't make a breaking change until we fix those scripts up